### PR TITLE
Remove debug multiplier on tile coord step size

### DIFF
--- a/modules/tilize-image.js
+++ b/modules/tilize-image.js
@@ -17,8 +17,8 @@ var geoCoords      = require('./geo-coords')
 function tilizeImage (filename, tileSize, overlap, callback){
   var tile_wid = tileSize;
   var tile_hei = tileSize;
-  var step_x = 4 * tile_wid - overlap;
-  var step_y = 4 * tile_hei - overlap;
+  var step_x = tile_wid - overlap;
+  var step_y = tile_hei - overlap;
 
   var basename = path.basename(filename).split('.')[0]
   var dirname  = path.dirname(filename)


### PR DESCRIPTION
Had left in a mutiplier of 4 on the step size for the tile loop, meaning tiles were being skipped.