### PR TITLE
Convert mosaic constructor to use options hash, update tests

### DIFF
--- a/generate-subjects.js
+++ b/generate-subjects.js
@@ -54,7 +54,14 @@ let mosaics;
 if (argv.provider !== 'file') {
   // Create mosaic instances from provided URLs
   mosaics = argv.mosaics.map((mosaic, i) => {
-    return new Mosaic(argv.provider, 'image' + (i + 1), mosaic, status, argv.tileSize, argv.tileOverlap);
+    return new Mosaic({
+      provider: argv.provider,
+      label: 'image' + (i + 1),
+      url: mosaic,
+      tileSize: argv.tileSize,
+      tileOverlap: argv.tileOverlap,
+      status: status
+    });
   });
 }
 

--- a/modules/mosaic.js
+++ b/modules/mosaic.js
@@ -6,13 +6,17 @@ const tilizeImage = require('./tilize-image');
 
 class Mosaic {
 
-  constructor(provider, label, url, status, tileSize, tileOverlap) {
-    this.provider = provider;
-    this.label = label;
-    this.url = url;
-    this.status = status;
-    this.tileSize = tileSize;
-    this.tileOverlap = tileOverlap;
+  /**
+   * @classdesc a Mosaic represents a large image ready to be tiled
+   */
+  constructor(options) {
+    this.provider = options.provider;
+    this.label = options.label;
+    this.showLabel = options.showLabel;
+    this.url = options.url;
+    this.tileSize = options.tileSize;
+    this.tileOverlap = options.tileOverlap;
+    this.status = options.status;
   }
 
   /**
@@ -60,7 +64,7 @@ class Mosaic {
 
       // Tile em up
       this.status.update('tilizing_mosaics', 'in-progress');
-      tilizeImage.tilizeMany(files, (err, tiles) => {
+      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, (err, tiles) => {
         if (err) {
           this.status.update('tilizing_mosaics', 'error');
           callback(err);

--- a/modules/tilize-image.js
+++ b/modules/tilize-image.js
@@ -85,12 +85,14 @@ function tilizeImage (filename, tileSize, overlap, callback){
 /**
  * Tilizes a set of images into a flat list of tiles. Assumes the source files are of the exactly same geographic bounds (i.e. same space, different time)
  * @param {Array<String>}  files
+ * @param {Number}         tile size
+ * @param {Number}         tile overlap size (x and y)
  * @param {Function}       callback
  */
-function tilizeImages(files, callback) {
+function tilizeImages(files, tileSize, tileOverlap, callback) {
   var tasks = [];
   for (var file of files) {
-    tasks.push(async.apply(tilizeImage, file, 480, 160));
+    tasks.push(async.apply(tilizeImage, file, tileSize, tileOverlap));
   }
   async.series(tasks, (err, tilesBySrc) => {
     var allTiles = [];

--- a/test/mosaic.js
+++ b/test/mosaic.js
@@ -9,9 +9,20 @@ const AOI = require('../modules/aoi');
 const Quad = require('../modules/quad');
 const Mosaic = require('../modules/mosaic');
 
+// Stub status class
+const Status = function () {};
+Status.prototype.update = Function.prototype;
+
 describe('Mosaic', () => {
   const aoi = new AOI('data/central-kathmandu.kml');
-  const mosaic = new Mosaic('planet-api', 'pre', 'http://example.com/mosaic_pre', 480, 160);
+  const mosaic = new Mosaic({
+    provider: 'planet-api',
+    label: 'pre',
+    url: 'http://example.com/mosaic_pre',
+    tileSize: 480,
+    tileOverlap: 160,
+    status: new Status()
+  });
 
   // Stub api functions so we can test with no network dependency
   sinon.stub(planetAPI, 'fetchQuadsFromAOI', (aoi, label, url, callback) => {
@@ -25,10 +36,18 @@ describe('Mosaic', () => {
 
   describe('create', () => {
     it('should set internal properties', function () {
+      expect(mosaic).to.have.property('provider');
       expect(mosaic).to.have.property('label');
-      expect(mosaic.label).to.equal('pre');
       expect(mosaic).to.have.property('url');
+      expect(mosaic).to.have.property('tileSize');
+      expect(mosaic).to.have.property('tileOverlap');
+      expect(mosaic).to.have.property('status');
+      expect(mosaic.provider).to.equal('planet-api');
+      expect(mosaic.label).to.equal('pre');
       expect(mosaic.url).to.equal('http://example.com/mosaic_pre');
+      expect(mosaic.tileSize).to.equal(480);
+      expect(mosaic.tileOverlap).to.equal(160);
+      expect(mosaic.status).to.be.an.instanceOf(Status);
     });
   });
 
@@ -68,8 +87,10 @@ describe('Mosaic', () => {
   describe('#createTilesForAOI', () => {
     it('should create tile tasks for each quad image', (done) => {
 
-       var tilizeStub = sinon.stub(tilizeImage, 'tilize', (file, w, h, callback) => {
+       var tilizeManyStub = sinon.stub(tilizeImage, 'tilizeMany', (files, tileSize, tileOverlap, callback) => {
          callback(null, [
+           '/path/to/some/tile',
+           '/path/to/some/tile',
            '/path/to/some/tile',
            '/path/to/some/tile'
          ]);
@@ -78,7 +99,10 @@ describe('Mosaic', () => {
        mosaic.createTilesForAOI(aoi, (err, tiles) => {
          expect(tiles).to.be.an('Array');
          expect(tiles.length).to.equal(4);
-         expect(tilizeStub.alwaysCalledWith('/path/to/some/file', 480, 160)).to.be.true;
+         expect(tilizeManyStub.args[0][0]).to.deep.equal(['/path/to/some/file', '/path/to/some/file']);
+         expect(tilizeManyStub.args[0][1]).to.equal(480);
+         expect(tilizeManyStub.args[0][2]).to.equal(160);
+         expect(tilizeManyStub.args[0][3]).to.be.an.instanceOf(Function);
          done();
        });
 


### PR DESCRIPTION
Mosaic tests were failing because of missing status instance. Took the opportunity to switch from long param list to an options hash for `Mosaic` constructor.

Also ensures custom tile sizes are used.
