### PR TITLE
Frame labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /planetary-response-network
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y ca-certificates sudo git curl bash-completion vim-tiny supervisor imagemagick libgdal-dev libimage-exiftool-perl make g++ python
+    apt-get install --no-install-recommends -y ca-certificates sudo git curl bash-completion vim-tiny supervisor ghostscript imagemagick libgdal-dev libimage-exiftool-perl make g++ python
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 RUN apt-get install --no-install-recommends -y nodejs && apt-get clean
 

--- a/generate-subjects.js
+++ b/generate-subjects.js
@@ -7,7 +7,6 @@ const Status        = require('./modules/status');
 const redis         = require('./lib/redis');
 const redisPubSub   = require('./lib/redis-pubsub');
 const User          = require('./lib/user-model');
-const exists        = require('./lib/exists');
 
 // Go
 const argv = yargs
@@ -79,7 +78,7 @@ if (argv.provider !== 'file') {
       tileOverlap: argv.tileOverlap,
       imOptions: {
         equalize: argv.equalize,
-        label: exists(argv.labels) ? argv.labels[i] : null, // 'image' + (i + 1), // Todo: maybe enable this for a future auto-label option?
+        label: argv.labels ? argv.labels[i] : null, // 'image' + (i + 1), // Todo: maybe enable this for a future auto-label option?
         labelPos: argv.labelPos
       },
       status: status
@@ -100,7 +99,7 @@ User.find(argv.userId, (err, user) => {
   if (argv.provider === 'file') {
     args.images = argv.images;
     args.equalize = argv.equalize;
-    args.labels = exists(argv.labels) ? argv.labels : null;
+    if (argv.labels) args.labels = argv.labels;
     args.labelPos = argv.labelPos;
     args.tileSize = argv.tileSize;
     args.tileOverlap = argv.tileOverlap;

--- a/lib/exists.js
+++ b/lib/exists.js
@@ -1,3 +1,0 @@
-module.exports = function exists(variable) {
-  return (typeof variable !== "undefined" && variable !== null);
-}

--- a/lib/exists.js
+++ b/lib/exists.js
@@ -1,0 +1,3 @@
+module.exports = function exists(variable) {
+  return (typeof variable !== "undefined" && variable !== null);
+}

--- a/modules/manifest.js
+++ b/modules/manifest.js
@@ -18,6 +18,8 @@ class Manifest {
    * @param  {Array<Mosaic>}         options.mosaics        List of mosaics included in the manifest
    * @param  {Aoi}                   options.aoi            An area of interest to use
    * @param  {Array<String>}         options.images         List of image filenames to use as source files instead of fetching from an API
+   * @param  {Array<String>}         options.labels         List of labels to overlay on tiles (first label applied to first source file/mosaic, and so on)
+   * @param  {Array<String>}         options.labelPos       Where to anchor labels (e.g. "south", "northwest")
    * @param  {Number}                options.projectId      Id of Panoptes project to which subjects should be sent
    * @param  {Number}                options.subjectSetId   Id of Panoptes subject set to which subjects should be sent
    * @param  {User}                  options.user           User running the job
@@ -38,6 +40,8 @@ class Manifest {
     this.status = options.status;
     this.user = options.user;
     this.images = options.images;
+    this.labels = options.labels;
+    this.labelPos = options.labelPos;
     if (this.images) {
       this.tileSize = options.tileSize;
       this.tileOverlap = options.tileOverlap;
@@ -69,8 +73,8 @@ class Manifest {
 
     if (this.images) {
       // Tile provided imagery
-      async.mapSeries(this.images, (tile, callback) => {
-        tilizeImage.tilize(tile, this.tileSize, this.tileOverlap, callback);
+      async.mapSeries(this.images, (image, callback) => {
+        tilizeImage.tilize(image, this.tileSize, this.tileOverlap, this.labels[this.images.indexOf(image)], this.labelPos, callback);
       }, handler);
     } else {
       // Fetch and tile imagery from mosaics

--- a/modules/manifest.js
+++ b/modules/manifest.js
@@ -9,6 +9,7 @@ const tilizeImage    = require('./tilize-image');
 const fs             = require('fs');
 const imgMeta        = require('./image-meta');
 const path           = require('path');
+const exists         = require('../lib/exists');
 
 class Manifest {
 
@@ -40,8 +41,15 @@ class Manifest {
     this.status = options.status;
     this.user = options.user;
     this.images = options.images;
-    this.labels = options.labels;
-    this.labelPos = options.labelPos;
+
+    this.imOptions = {};
+    this.imOptions.equalize = options.equalize;
+
+    if( exists(options.labels) ) {
+      this.imOptions.labels = options.labels;
+      this.imOptions.labelPos = options.labelPos;
+    }
+
     if (this.images) {
       this.tileSize = options.tileSize;
       this.tileOverlap = options.tileOverlap;
@@ -75,7 +83,12 @@ class Manifest {
       // Tile provided imagery
       async.mapSeries(this.images, (image, callback) => {
         // TO DO: accept case with no labels
-        tilizeImage.tilize(image, this.tileSize, this.tileOverlap, this.labels[this.images.indexOf(image)], this.labelPos, callback);
+        let options = {
+          equalize: this.imOptions.equalize,
+          label:    exists(this.imOptions.labels)   ? this.imOptions.labels[this.images.indexOf(image)] : null,
+          labelPos: exists(this.imOptions.labelPos) ? this.imOptions.labelPos : null
+        }
+        tilizeImage.tilize(image, this.tileSize, this.tileOverlap, options, callback);
       }, handler);
     } else {
       // Fetch and tile imagery from mosaics

--- a/modules/manifest.js
+++ b/modules/manifest.js
@@ -9,7 +9,6 @@ const tilizeImage    = require('./tilize-image');
 const fs             = require('fs');
 const imgMeta        = require('./image-meta');
 const path           = require('path');
-const exists         = require('../lib/exists');
 
 class Manifest {
 
@@ -45,7 +44,7 @@ class Manifest {
     this.imOptions = {};
     this.imOptions.equalize = options.equalize;
 
-    if( exists(options.labels) ) {
+    if(options.labels) {
       this.imOptions.labels = options.labels;
       this.imOptions.labelPos = options.labelPos;
     }
@@ -82,8 +81,8 @@ class Manifest {
       async.mapSeries(this.images, (image, callback) => {
         let options = {
           equalize: this.imOptions.equalize,
-          label:    exists(this.imOptions.labels)   ? this.imOptions.labels[this.images.indexOf(image)] : null,
-          labelPos: exists(this.imOptions.labelPos) ? this.imOptions.labelPos : null
+          label:    this.imOptions.labels   ? this.imOptions.labels[this.images.indexOf(image)] : null,
+          labelPos: this.imOptions.labelPos
         }
         tilizeImage.tilize(image, this.tileSize, this.tileOverlap, options, callback);
       }, handler);

--- a/modules/manifest.js
+++ b/modules/manifest.js
@@ -64,7 +64,6 @@ class Manifest {
     const handler = (err, tileSets) => {
       this.status.update('tilizing_mosaics', 'done');
       createSubjects.subjectsFromTileSets(tileSets, (err, subjects) => {
-        // console.log('SUBJECTS.LENGTH = ', subjects.length); // ---STI
         if (err) return callback(err);
         subjects = subjects.map(subject => {
           subject.links = {
@@ -73,7 +72,6 @@ class Manifest {
           };
           return subject;
         });
-        // console.log('SUBJECTS: ', subjects); // --STI
         this.generateManifest(subjects); // May want to move this somewhere else?
         callback(null, subjects);
       });
@@ -82,7 +80,6 @@ class Manifest {
     if (this.images) {
       // Tile provided imagery
       async.mapSeries(this.images, (image, callback) => {
-        // TO DO: accept case with no labels
         let options = {
           equalize: this.imOptions.equalize,
           label:    exists(this.imOptions.labels)   ? this.imOptions.labels[this.images.indexOf(image)] : null,

--- a/modules/manifest.js
+++ b/modules/manifest.js
@@ -74,6 +74,7 @@ class Manifest {
     if (this.images) {
       // Tile provided imagery
       async.mapSeries(this.images, (image, callback) => {
+        // TO DO: accept case with no labels
         tilizeImage.tilize(image, this.tileSize, this.tileOverlap, this.labels[this.images.indexOf(image)], this.labelPos, callback);
       }, handler);
     } else {

--- a/modules/mosaic.js
+++ b/modules/mosaic.js
@@ -67,10 +67,7 @@ class Mosaic {
 
       // Tile em up
       this.status.update('tilizing_mosaics', 'in-progress');
-
-      let options = this.imOptions;
-
-      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, options, (err, tiles) => {
+      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, this.imOptions, (err, tiles) => {
         if (err) {
           this.status.update('tilizing_mosaics', 'error');
           callback(err);

--- a/modules/mosaic.js
+++ b/modules/mosaic.js
@@ -20,8 +20,6 @@ class Mosaic {
     this.tileSize = options.tileSize;
     this.tileOverlap = options.tileOverlap;
     this.status = options.status;
-
-    console.log('MOSAIC OPTIONS = ', options);
   }
 
   /**

--- a/modules/mosaic.js
+++ b/modules/mosaic.js
@@ -13,6 +13,7 @@ class Mosaic {
     this.provider = options.provider;
     this.label = options.label;
     this.showLabel = options.showLabel;
+    this.labelPos = options.labelPos;
     this.url = options.url;
     this.tileSize = options.tileSize;
     this.tileOverlap = options.tileOverlap;
@@ -64,7 +65,8 @@ class Mosaic {
 
       // Tile em up
       this.status.update('tilizing_mosaics', 'in-progress');
-      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, (err, tiles) => {
+      let label = this.showLabel ? this.label : '';
+      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, label, this.labelPos, (err, tiles) => {
         if (err) {
           this.status.update('tilizing_mosaics', 'error');
           callback(err);

--- a/modules/mosaic.js
+++ b/modules/mosaic.js
@@ -11,13 +11,17 @@ class Mosaic {
    */
   constructor(options) {
     this.provider = options.provider;
-    this.label = options.label;
-    this.showLabel = options.showLabel;
-    this.labelPos = options.labelPos;
+    this.imOptions = {
+      equalize: options.imOptions.equalize,
+      label: options.imOptions.label,
+      labelPos: options.imOptions.labelPos
+    };
     this.url = options.url;
     this.tileSize = options.tileSize;
     this.tileOverlap = options.tileOverlap;
     this.status = options.status;
+
+    console.log('MOSAIC OPTIONS = ', options);
   }
 
   /**
@@ -65,8 +69,10 @@ class Mosaic {
 
       // Tile em up
       this.status.update('tilizing_mosaics', 'in-progress');
-      let label = this.showLabel ? this.label : '';
-      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, label, this.labelPos, (err, tiles) => {
+
+      let options = this.imOptions;
+
+      tilizeImage.tilizeMany(files, this.tileSize, this.tileOverlap, options, (err, tiles) => {
         if (err) {
           this.status.update('tilizing_mosaics', 'error');
           callback(err);

--- a/modules/panoptes-api.js
+++ b/modules/panoptes-api.js
@@ -25,7 +25,7 @@ function saveSubjects(user, subjects, callback){
   // Inject our access token into api client
   api.headers.Authorization = 'Bearer ' + user.get('accessToken')
 
-  api.update({'params.admin': true});  // careful when using admin mode!
+  // api.update({'params.admin': true});  // careful when using admin mode!
   async.eachSeries(subjects, saveSubject, (err, result) => {
     // Clear access token
     api.headers.Authorization = null

--- a/modules/tilize-image.js
+++ b/modules/tilize-image.js
@@ -50,35 +50,87 @@ function tilizeImage (filename, tileSize, overlap, label, labelPos, callback){
       center       : geoCoords.pxToWgs84(ds, offset_x + tile_wid / 2, offset_y + tile_hei / 2)
     }
 
+
+  /* ImageMagick command
+  convert Pedernales2-Before.tif \
+    -crop 10000x10000+5000+5000 \
+    -extent 10000x10000 \
+    -background white \
+    -compose copy \
+    +repage \
+    -gravity south \
+    -stroke '#000C' -strokewidth 2 -pointsize 14 \
+    -annotate 0 'Faerie Dragon' -stroke none -fill white \
+    -annotate 0 'Faerie Dragon' \
+    foo_splice.jpg
+    */
+
+
+    let imCommand = `${filename}[0] -crop ${tile_wid}x${tile_hei}+${offset_x}+${offset_y} -extent ${tile_wid}x${tile_hei} -background white -compose copy +repage -gravity south -stroke black -strokewidth 2 -pointsize 14 -annotate 0 ${label} -stroke none -fill white -annotate 0 ${label} ${outfilename}`;
+    // let convertArgs = [ imCommand.split(' ') ];
+    let convertArgs =  [ [ 'data/pedernales-before.tif[0]',
+    '-crop',
+    '480x480+0+1600',
+    '-extent',
+    '480x480',
+    '-background',
+    'white',
+    '-compose',
+    'copy',
+    '+repage',
+    '-gravity',
+    'south',
+    '-stroke',
+    'black',
+    '-strokewidth',
+    '2',
+    '-pointsize',
+    '14',
+    '-annotate', '0 gfhjkl',
+    '-stroke', 'none',
+    '-fill', 'white',
+    '-annotate', '0 gfhjkl',
+    'data/pedernales-before_0_5.jpeg' ] ];
+
     // Should we -normalize each tile?
     // PRO: Ensures contrast is stretched if images are too dark or washed out
     // CON: May take longer to process?
-    let convertArgs = [
-      [
-        filename + '[0]',
-        '-equalize',
-        '-crop', crop_option,
-        '-background', 'black',
-        '-extent', extent_option,
-        '-compose', 'Copy',
-        '+repage',
-        outfilename
-      ]
-    ];
-    if (label) {
-      convertArgs.push([
-        outfilename,
-        '-gravity', labelPos,
-        '-pointsize', 14,
-        '-stroke', '#000C',
-        '-strokewidth', 2,
-        '-annotate', 0, label,
-        '-stroke', 'none',
-        '-fill', 'white',
-        '-annotate', 0, label,
-        outfilename
-      ]);
-    }
+    console.log('outfilename = ', outfilename);
+    // let convertArgs = [
+    //   [
+    //     filename + '[0]',
+    //     '-equalize',
+    //     '-crop', crop_option,
+    //     '-extent', extent_option,
+    //     '-background', 'black',
+    //     // '-compose', 'copy',
+    //     '+repage',
+    //     '-gravity', labelPos,
+    //     '-stroke', '#000C',
+    //     '-strokewidth', 2,
+    //     '-pointsize', 14,
+    //     '-annotate', 0, label,
+    //     '-stroke none',
+    //     '-fill white',
+    //     '-annotate', 0, label,
+    //     outfilename
+    //   ]
+    // ];
+    console.log('convertArgs = ', convertArgs);
+    // if (label) {
+    //   convertArgs.push([
+    //     outfilename ,
+    //     '-gravity', labelPos,
+    //     '-pointsize', 14,
+    //     '-stroke', '#000C',
+    //     '-strokewidth', 2,
+    //     '-annotate', 0, label,
+    //     '-stroke', 'none',
+    //     '-fill', 'white',
+    //     '-annotate', 0, label,
+    //     outfilename
+    //   ]);
+    // }
     async.eachSeries(convertArgs, im.convert, (err, results) => {
       if (err) return done(err);
       imgMeta.write(outfilename, '-userComment', coords, done)  // write coordinates to tile image metadata

--- a/modules/tilize-image.js
+++ b/modules/tilize-image.js
@@ -7,7 +7,6 @@ var gdal           = require('gdal')
 var async          = require('async')
 var imgMeta        = require('./image-meta')
 var geoCoords      = require('./geo-coords')
-var exists         = require('../lib/exists')
 
 /**
  * Splits an image into tiles
@@ -63,7 +62,7 @@ function tilizeImage (filename, tileSize, overlap, options, callback){
     }
 
     // add label-generating arguments
-    if( exists(options.label) ) {
+    if(options.label) {
       convertArgs = convertArgs.concat([
         '-gravity', 'south',
         '-stroke', 'black',

--- a/modules/tilize-image.js
+++ b/modules/tilize-image.js
@@ -69,6 +69,7 @@ function tilizeImage (filename, tileSize, overlap, label, labelPos, callback){
       convertArgs.push([
         outfilename,
         '-gravity', labelPos,
+        '-pointsize', 14,
         '-stroke', '#000C',
         '-strokewidth', 2,
         '-annotate', 0, label,

--- a/test/mosaic.js
+++ b/test/mosaic.js
@@ -17,9 +17,11 @@ describe('Mosaic', () => {
   const aoi = new AOI('data/central-kathmandu.kml');
   const mosaic = new Mosaic({
     provider: 'planet-api',
-    label: 'pre',
-    labelPos: 'south',
-    showLabel: true,
+    imOptions: {
+      equalize: true,
+      label: 'imagelabel',
+      labelPos: 'south'
+    },
     url: 'http://example.com/mosaic_pre',
     tileSize: 480,
     tileOverlap: 160,
@@ -39,15 +41,15 @@ describe('Mosaic', () => {
   describe('create', () => {
     it('should set internal properties', function () {
       expect(mosaic).to.have.property('provider');
-      expect(mosaic).to.have.property('label');
-      expect(mosaic).to.have.property('showLabel');
+      expect(mosaic).to.have.property('imOptions');
       expect(mosaic).to.have.property('url');
       expect(mosaic).to.have.property('tileSize');
       expect(mosaic).to.have.property('tileOverlap');
       expect(mosaic).to.have.property('status');
       expect(mosaic.provider).to.equal('planet-api');
-      expect(mosaic.label).to.equal('pre');
-      expect(mosaic.showLabel).to.equal(true);
+      expect(mosaic.imOptions.equalize).to.equal(true);
+      expect(mosaic.imOptions.label).to.equal('imagelabel');
+      expect(mosaic.imOptions.labelPos).to.equal('south');
       expect(mosaic.url).to.equal('http://example.com/mosaic_pre');
       expect(mosaic.tileSize).to.equal(480);
       expect(mosaic.tileOverlap).to.equal(160);
@@ -91,7 +93,7 @@ describe('Mosaic', () => {
   describe('#createTilesForAOI', () => {
     it('should create tile tasks for each quad image', (done) => {
 
-       var tilizeManyStub = sinon.stub(tilizeImage, 'tilizeMany', (files, tileSize, tileOverlap, label, labelPos, callback) => {
+       var tilizeManyStub = sinon.stub(tilizeImage, 'tilizeMany', (files, tileSize, tileOverlap, options, callback) => {
          callback(null, [
            '/path/to/some/tile',
            '/path/to/some/tile',
@@ -106,9 +108,8 @@ describe('Mosaic', () => {
          expect(tilizeManyStub.args[0][0]).to.deep.equal(['/path/to/some/file', '/path/to/some/file']);
          expect(tilizeManyStub.args[0][1]).to.equal(480);
          expect(tilizeManyStub.args[0][2]).to.equal(160);
-         expect(tilizeManyStub.args[0][3]).to.equal('pre');
-         expect(tilizeManyStub.args[0][4]).to.equal('south');
-         expect(tilizeManyStub.args[0][5]).to.be.an.instanceOf(Function);
+         expect(tilizeManyStub.args[0][3]).to.contain.all.keys(['equalize', 'label', 'labelPos']);
+         expect(tilizeManyStub.args[0][4]).to.be.an.instanceOf(Function);
          done();
        });
 

--- a/test/mosaic.js
+++ b/test/mosaic.js
@@ -18,6 +18,8 @@ describe('Mosaic', () => {
   const mosaic = new Mosaic({
     provider: 'planet-api',
     label: 'pre',
+    labelPos: 'south',
+    showLabel: true,
     url: 'http://example.com/mosaic_pre',
     tileSize: 480,
     tileOverlap: 160,
@@ -38,12 +40,14 @@ describe('Mosaic', () => {
     it('should set internal properties', function () {
       expect(mosaic).to.have.property('provider');
       expect(mosaic).to.have.property('label');
+      expect(mosaic).to.have.property('showLabel');
       expect(mosaic).to.have.property('url');
       expect(mosaic).to.have.property('tileSize');
       expect(mosaic).to.have.property('tileOverlap');
       expect(mosaic).to.have.property('status');
       expect(mosaic.provider).to.equal('planet-api');
       expect(mosaic.label).to.equal('pre');
+      expect(mosaic.showLabel).to.equal(true);
       expect(mosaic.url).to.equal('http://example.com/mosaic_pre');
       expect(mosaic.tileSize).to.equal(480);
       expect(mosaic.tileOverlap).to.equal(160);
@@ -87,7 +91,7 @@ describe('Mosaic', () => {
   describe('#createTilesForAOI', () => {
     it('should create tile tasks for each quad image', (done) => {
 
-       var tilizeManyStub = sinon.stub(tilizeImage, 'tilizeMany', (files, tileSize, tileOverlap, callback) => {
+       var tilizeManyStub = sinon.stub(tilizeImage, 'tilizeMany', (files, tileSize, tileOverlap, label, labelPos, callback) => {
          callback(null, [
            '/path/to/some/tile',
            '/path/to/some/tile',
@@ -102,7 +106,9 @@ describe('Mosaic', () => {
          expect(tilizeManyStub.args[0][0]).to.deep.equal(['/path/to/some/file', '/path/to/some/file']);
          expect(tilizeManyStub.args[0][1]).to.equal(480);
          expect(tilizeManyStub.args[0][2]).to.equal(160);
-         expect(tilizeManyStub.args[0][3]).to.be.an.instanceOf(Function);
+         expect(tilizeManyStub.args[0][3]).to.equal('pre');
+         expect(tilizeManyStub.args[0][4]).to.equal('south');
+         expect(tilizeManyStub.args[0][5]).to.be.an.instanceOf(Function);
          done();
        });
 


### PR DESCRIPTION
Adds frame label support via `--labels` on `generate-subjects.js`. Not hooked up to requests from the frontend but good enough for current Ecuador work.

Labels are assigned to source files and applied to each tile generated from that source file, e.g.:

`node generate-subjects --images ecuador_before.tif ecuador_after.tif --labels before after`
