### PR TITLE
Tilize cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,5 @@
+const yargs = require('yargs');
+const argv = yargs
+  .command(require('./tilize'))
+  .help()
+  .argv;

--- a/modules/tilize-image.js
+++ b/modules/tilize-image.js
@@ -18,6 +18,7 @@ var geoCoords      = require('./geo-coords')
  * @param  {Function} callback
  */
 function tilizeImage (filename, tileSize, overlap, options, callback){
+  options = options || {};
   var tile_wid = tileSize;
   var tile_hei = tileSize;
   var step_x = tile_wid - overlap;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "consumer": "nodemon generator/main.js",
     "start": "npm run producer & npm run consumer",
     "keygen": "openssl req -nodes -newkey rsa:2048 -keyout server.key -out server.csr -subj '/C=GB/ST=/L=/O=Zooniverse/OU=/CN=localhost' && openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt && rm server.csr && echo 'Generated key server.key, certificate server.crt'",
-    "test": "mocha"
+    "test": "mocha",
+    "tilize": "node tilize.js"
   },
   "dependencies": {
     "async": "~1.5.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "socket.io": "^1.4.5",
     "togeojson": "^0.13.0",
     "xmlhttprequest-cookie": "^0.9.4",
-    "yargs": "^3.31.0"
+    "yargs": "^4.6.0"
   },
   "devDependencies": {
     "nodemon": "^1.9.0",

--- a/tilize.js
+++ b/tilize.js
@@ -1,0 +1,21 @@
+const yargs = require('yargs');
+const tilize = require('./modules/tilize-image');
+
+const argv = yargs
+  .usage('$0 <options> image1 [image2...]')
+  .option('size', {
+    describe: 'Square size for tiles',
+    default: 500
+  })
+  .option('overlap', {
+    describe: 'Tile overlap (both x and y)',
+    default: 250
+  })
+  .demand(1)
+  .argv;
+
+if (argv._.length === 1) {
+  tilize.tilize(argv._[0], argv.size, argv.overlap);
+} else {
+  tilize.tilizeMany(argv._, argv.size, argv.overlap);
+}

--- a/tilize.js
+++ b/tilize.js
@@ -1,3 +1,4 @@
+'use strict';
 const yargs = require('yargs');
 const tilize = require('./modules/tilize-image');
 
@@ -11,11 +12,29 @@ const argv = yargs
     describe: 'Tile overlap (both x and y)',
     default: 250
   })
+  .option('equalize', {
+    describe: 'Equalize histogram to stretch contrast',
+    boolean: true
+  })
+  .option('labels', {
+    describe: 'Space-separated list of labels to overlay on tiles (first label will be used for tiles from first image, and so on)',
+    array: true
+  })
   .demand(1)
   .argv;
 
+let options = {};
+if (argv.labels) options.labels = argv.labels;
+if (argv.equalize) options.equalize = argv.equalize;
+
+function done (err, files) {
+  if (err) throw err;
+  console.log('Done, created tiles:')
+  console.log(files.join('\n'));
+}
+
 if (argv._.length === 1) {
-  tilize.tilize(argv._[0], argv.size, argv.overlap);
+  tilize.tilize(argv._[0], argv.size, argv.overlap, options, done);
 } else {
-  tilize.tilizeMany(argv._, argv.size, argv.overlap);
+  tilize.tilizeMany(argv._, argv.size, argv.overlap, options, done);
 }

--- a/tilize.js
+++ b/tilize.js
@@ -1,40 +1,81 @@
 'use strict';
+const async = require('async');
 const yargs = require('yargs');
 const tilize = require('./modules/tilize-image');
+const isChild = require.main !== module;
 
-const argv = yargs
-  .usage('$0 <options> image1 [image2...]')
-  .option('size', {
-    describe: 'Square size for tiles',
-    default: 500
-  })
-  .option('overlap', {
-    describe: 'Tile overlap (both x and y)',
-    default: 250
-  })
-  .option('equalize', {
-    describe: 'Equalize histogram to stretch contrast',
-    boolean: true
-  })
-  .option('labels', {
-    describe: 'Space-separated list of labels to overlay on tiles (first label will be used for tiles from first image, and so on)',
-    array: true
-  })
-  .demand(1)
-  .argv;
+function cli (yargs) {
+  let demand = isChild ? 2 : 1;
 
-let options = {};
-if (argv.labels) options.labels = argv.labels;
-if (argv.equalize) options.equalize = argv.equalize;
-
-function done (err, files) {
-  if (err) throw err;
-  console.log('Done, created tiles:')
-  console.log(files.join('\n'));
+  return yargs
+    .usage('$0 <options> image1 [image2...]')
+    .option('size', {
+      describe: 'Square size for tiles',
+      default: 500
+    })
+    .option('overlap', {
+      describe: 'Tile overlap (both x and y)',
+      default: 250
+    })
+    .option('equalize', {
+      describe: 'Equalize histogram to stretch contrast',
+      boolean: true
+    })
+    .option('labels', {
+      describe: 'Space-separated list of labels to overlay on tiles (first label will be used for tiles from first image, and so on)',
+      array: true
+    })
+    .demand(demand)
+    .check(argv => {
+      // Convenience named positional args array not initialised yet, handle it ourselves
+      argv.images = isChild ? argv._.slice(1) : argv._;
+      // Ensure number of images and labels match if using labels
+      if (argv.labels && argv.labels.length != argv.images.length) {
+        throw new Error('If supplying labels, the number of labels must match the number of input images');
+      }
+      return true;
+    });
 }
 
-if (argv._.length === 1) {
-  tilize.tilize(argv._[0], argv.size, argv.overlap, options, done);
-} else {
-  tilize.tilizeMany(argv._, argv.size, argv.overlap, options, done);
+function run (argv) {
+  let options = {};
+  if (argv.equalize) options.equalize = argv.equalize;
+
+  // One image or multiple?
+  let single = argv.images.length === 1;
+
+  function done (err, files) {
+    if (err) throw err;
+    console.log('Done, created tiles:')
+    console.log(single ? files.join('\n') : files.map(files => files.join('\n')).join('\n'));
+  }
+
+  if (single) {
+    // Assign correct label
+    if (argv.labels) options.label = argv.labels[0];
+    // Tile!
+    tilize.tilize(argv.images[0], argv.size, argv.overlap, options, done);
+  } else {
+    if (argv.labels) options.labels = argv.labels;
+    // Process each image in turn
+    async.mapSeries(argv.images, (image, done) => {
+      // Assign correct label
+      let idx = argv.images.indexOf(image);
+      let imageOptions = options;
+      imageOptions.label = options.labels[idx];
+      // Tile!
+      tilize.tilize(image, argv.size, argv.overlap, imageOptions, done);
+    }, done);
+  }
 }
+
+// Allow running directly...
+if (!isChild) {
+  run(cli(yargs).argv);
+}
+// ...and requiring in a yargs subcommand
+exports.command = 'tilize [images..]'
+exports.describe = 'Tilize GeoTIFF image(s)'
+exports.builder = yargs => cli(yargs);
+exports.handler = run;
+


### PR DESCRIPTION
Wraps a cli around the "tilize" step.

I've written it such that it can be used as a standalone command or loaded as a [subcommand](https://www.npmjs.com/package/yargs#commandmodule) of [another cli](https://github.com/zooniverse/planetary-response-network/blob/9ad434ac198e3fb2db13ba376d656f77a5c2d9d2/cli.js) - thoughts on this are welcome! Hopefully it's a useful template for doing the other commands.