### PR TITLE
Use refresh tokens

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,26 +1,29 @@
 'use strict';
-module.exports = app => {
-  const async = require('async');
-  const redis = require('./redis');
-  const session = require('express-session');
-  const RedisStore = require('connect-redis')(session);
-  const request = require('request');
-  const passport = require('passport');
-  const OAuth2Strategy = require('passport-oauth2');
-  const bodyParser = require('body-parser');
-  const cookieParser = require('cookie-parser');
-  const User = require('./user-model.js');
-  const panoptesClient = require('panoptes-client/lib/api-client');
-  const ensureLogin = require('../middleware/ensure-login');
-  const PANOPTES_ROOT = panoptesClient.root.split('/').slice(0, -1).join('/'); // Remove trailing /api
-  const OAUTH_CONFIG = {
-    authorizationURL: PANOPTES_ROOT+'/oauth/authorize',
-    tokenURL: PANOPTES_ROOT+'/oauth/token',
-    clientID: process.env.PANOPTES_API_APPLICATION,
-    clientSecret: process.env.PANOPTES_API_SECRET,
-    callbackURL: process.env.PRN_CALLBACK_URI || 'https://localhost:3736/auth/callback'
-  };
 
+const async = require('async');
+const redis = require('./redis');
+const session = require('express-session');
+const RedisStore = require('connect-redis')(session);
+const request = require('request');
+const passport = require('passport');
+const OAuth2Strategy = require('passport-oauth2');
+const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser');
+const User = require('./user-model.js');
+const panoptesClientFactory = require('../modules/panoptes-client-factory');
+const OAUTH_CONFIG = {
+  authorizationURL: panoptesClientFactory.config.oauthHost+'/oauth/authorize',
+  tokenURL: panoptesClientFactory.config.oauthHost+'/oauth/token',
+  clientID: process.env.PANOPTES_API_APPLICATION,
+  clientSecret: process.env.PANOPTES_API_SECRET,
+  callbackURL: process.env.PRN_CALLBACK_URI || 'https://localhost:3736/auth/callback'
+};
+const JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json',
+};
+
+function setupMiddlewares(app) {
   // Store user session in redis
   app.use(session({
     store: new RedisStore({
@@ -92,72 +95,82 @@ module.exports = app => {
     delete profile.refreshToken;
     res.send(profile);
   });
+}
 
-  /**
-   * Updates our local user with the token and profile data from Panoptes' oauth response
-   * @param {String}    accessToken        the user's access token
-   * @param {String}    refreshToken       the user's refresh token
-   * @param {Object}    params             data about the tokens
-   * @param {Number}    params.created_at  access token creation timestamp
-   * @param {Number}    params.expires_in  access token validity lifetime, in seconds
-   * @param {Object}    profile            empty - Panoptes doesn't return a profile here
-   * @param {Function}  done               callback
-   */
-  function handleOauthResponse(accessToken, refreshToken, params, profile, done) {
-    // Panoptes doesn't include profile in oauth response; fetch now
-    const userData = {
-      accessToken: accessToken,
-      refreshToken: refreshToken,
-      accessTokenExpiresAt: params.created_at + params.expires_in
-    };
+/**
+ * Updates our local user with the token and profile data from Panoptes' oauth response
+ * @param {String}    accessToken        the user's access token
+ * @param {String}    refreshToken       the user's refresh token
+ * @param {Object}    params             data about the tokens
+ * @param {Number}    params.created_at  access token creation timestamp
+ * @param {Number}    params.expires_in  access token validity lifetime, in seconds
+ * @param {Object}    profile            empty - Panoptes doesn't return a profile here
+ * @param {Function}  done               callback
+ */
+function handleOauthResponse(accessToken, refreshToken, params, profile, done) {
+  // Panoptes doesn't include profile in oauth response; fetch now
+  const userData = {
+    accessToken: accessToken,
+    refreshToken: refreshToken,
+    accessTokenExpiresAt: params.created_at + params.expires_in
+  };
 
-    async.waterfall([
-      async.apply(getPanoptesProfileFromAccessToken, accessToken),
-      (profile, done) => {
-        getUserFromAccessToken(accessToken, (err, user) => {
-          userData.username = profile.login;
-          userData.displayName = profile.display_name;
-          user.update(userData, done);
-        });
-      }
-    ], done);
+  async.waterfall([
+    async.apply(getPanoptesProfileFromAccessToken, accessToken),
+    (profile, done) => {
+      getUserFromAccessToken(accessToken, (err, user) => {
+        userData.username = profile.login;
+        userData.displayName = profile.display_name;
+        user.update(userData, done);
+      });
+    }
+  ], done);
+}
+
+/**
+ * Uses an access token to get a local user
+ * @param {String}   accessToken
+ * @param {Function} done
+ */
+function getUserFromAccessToken(accessToken, done) {
+  // TODO can we query redis for the user with the access token (i.e. bypass Panoptes)?
+  getPanoptesProfileFromAccessToken(accessToken, (err, profile) => {
+    User.findOrCreate(profile.id, done);
+  });
+}
+
+/**
+ * Uses an access token to get the user's profile from Panoptes
+ * @param {String}   accessToken
+ * @param {Function} done
+ */
+function getPanoptesProfileFromAccessToken(accessToken, done) {
+  request.get(panoptesClientFactory.config.host+'/api/me', {
+    auth: {
+      bearer: accessToken
+    },
+    headers: {
+      Accept: 'application/vnd.api+json; version=1'
+    }
+  }, (err, res, body) => {
+    if (err) return done(err);
+    try {
+      body = JSON.parse(body);
+    } catch(e) {
+      done(e);
+    }
+
+    done(null, body.users[0]);
+  });
+}
+
+function ensureLogin(req, res, next) {
+  if (req.user) {
+    next();
+  } else {
+    res.status(401);
+    res.send('You are not logged in');
   }
+}
 
-  /**
-   * Uses an access token to get a local user
-   * @param {String}   accessToken
-   * @param {Function} done
-   */
-  function getUserFromAccessToken(accessToken, done) {
-    // TODO can we query redis for the user with the access token (i.e. bypass Panoptes)?
-    getPanoptesProfileFromAccessToken(accessToken, (err, profile) => {
-      User.findOrCreate(profile.id, done);
-    });
-  }
-
-  /**
-   * Uses an access token to get the user's profile from Panoptes
-   * @param {String}   accessToken
-   * @param {Function} done
-   */
-  function getPanoptesProfileFromAccessToken(accessToken, done) {
-    request.get(PANOPTES_ROOT+'/api/me', {
-      auth: {
-        bearer: accessToken
-      },
-      headers: {
-        Accept: 'application/vnd.api+json; version=1'
-      }
-    }, (err, res, body) => {
-      if (err) return done(err);
-
-      try {
-        body = JSON.parse(body);
-      } catch(e) {
-        done(e);
-      }
-
-      done(null, body.users[0]);
-    });
-  }
-};
+module.exports = { setupMiddlewares, ensureLogin };

--- a/middleware/panoptes-proxy.js
+++ b/middleware/panoptes-proxy.js
@@ -19,26 +19,30 @@ class PanoptesProxy {
   }
 
   getProjects(req, res, next) {
-    const client = panoptesClientFactory.getClientForUser(req.user);
-    const query = this.getPanoptesCollectionQuery(req);
-    query.owner = req.user.get('displayName');
+    panoptesClientFactory.getClientForUser(req.user)
+    .then(client => {
+      const query = this.getPanoptesCollectionQuery(req);
+      query.owner = req.user.get('displayName');
 
-    client.type('projects').get(query).then(
-      projects => res.send(projects),
-      reason => next(new Error(reason))
-    );
+      client.type('projects').get(query).then(
+        projects => res.send(projects),
+        reason => next(new Error(reason))
+      );
+    });
   }
 
   getSubjectSets(req, res, next) {
-    const client = panoptesClientFactory.getClientForUser(req.user);
-    const query = this.getPanoptesCollectionQuery(req);
-    if (req.query.project_id) query.project_id = req.query.project_id;
-    if (req.query.workflow_id) query.workflow_id = req.query.workflow_id;
+    panoptesClientFactory.getClientForUser(req.user)
+    .then(client => {
+      const query = this.getPanoptesCollectionQuery(req);
+      if (req.query.project_id) query.project_id = req.query.project_id;
+      if (req.query.workflow_id) query.workflow_id = req.query.workflow_id;
 
-    client.type('subject_sets').get(query).then(
-      projects => res.send(projects),
-      reason => next(new Error(reason))
-    );
+      client.type('subject_sets').get(query).then(
+        projects => res.send(projects),
+        reason => next(new Error(reason))
+      );
+    });
   }
 }
 

--- a/modules/panoptes-api.js
+++ b/modules/panoptes-api.js
@@ -6,8 +6,9 @@ var clientFactory        = require('./panoptes-client-factory')
 exports.saveSubjects = saveSubjects
 
 function saveSubject(user, subject, callback) {
-  clientFactory.getClientForUser(user);
+  clientFactory.getClientForUser(user)
   .then(client => {
+    // client.update({'params.admin': true});  // careful when using admin mode!
     return client.type('subjects').create(subject).save()
   })
   .then(function(subject){
@@ -20,6 +21,5 @@ function saveSubject(user, subject, callback) {
 }
 
 function saveSubjects(user, subjects, callback){
-  // api.update({'params.admin': true});  // careful when using admin mode!
   async.eachSeries(subjects, async.apply(saveSubject, user), callback)
 }

--- a/modules/panoptes-api.js
+++ b/modules/panoptes-api.js
@@ -1,20 +1,22 @@
 'use strict';
 global.XMLHttpRequest = require('xmlhttprequest-cookie').XMLHttpRequest
 var async             = require('async')
-var apiFactory        = require('./panoptes-client-factory')
+var clientFactory        = require('./panoptes-client-factory')
 
 exports.saveSubjects = saveSubjects
 
 function saveSubject(user, subject, callback) {
-  var api  = apiFactory.getClientForUser(user);
-  api.type('subjects').create(subject).save()
-    .then(function(subject){
-      console.log("Subject created: ,", subject ); // DEBUG CODE
-      callback(null, subject)
-    })
-    .catch(function(error) {
-      callback(error);
-    })
+  clientFactory.getClientForUser(user);
+  .then(client => {
+    return client.type('subjects').create(subject).save()
+  })
+  .then(function(subject){
+    console.log("Subject created: ,", subject ); // DEBUG CODE
+    callback(null, subject)
+  })
+  .catch(function(error) {
+    callback(error);
+  })
 }
 
 function saveSubjects(user, subjects, callback){

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const path           = require('path')
 const fs             = require('fs')
 const https          = require('https')
 const cors           = require('cors')
-const ensureLogin    = require('./middleware/ensure-login')
+const auth           = require('./lib/auth')
 const getJobs        = require('./middleware/get-jobs')
 const deleteJob      = require('./middleware/delete-job')
 const panoptesProxy  = require('./middleware/panoptes-proxy')
@@ -62,21 +62,19 @@ redis.on('pmessage', function (channel, pattern, message) {
 const upload = multer({ dest: path.join(__dirname, './uploaded_aois') })
 app.use(morgan('combined'))
 
-////////////////////////////////////////////////////////////////////
-require('./lib/auth')(app);
-////////////////////////////////////////////////////////////////////
+// Setup auth
+auth.setupMiddlewares(app);
 
 // Handle AOI uploads
-app.post('/aois', ensureLogin, upload.single('file'), processAoi.runner({useQueue: argv.useQueue} ))
+app.post('/aois', auth.ensureLogin, upload.single('file'), processAoi.runner({useQueue: argv.useQueue} ))
 
-// Builds route
-app.get('/jobs', ensureLogin, getJobs)
-
-app.delete('/jobs/:job_id', ensureLogin, deleteJob)
+// Job routes
+app.get('/jobs', auth.ensureLogin, getJobs)
+app.delete('/jobs/:job_id', auth.ensureLogin, deleteJob)
 
 // Proxy panoptes calls
-app.get('/projects', ensureLogin, panoptesProxy.getProjects)
-app.get('/subject-sets', ensureLogin, panoptesProxy.getSubjectSets)
+app.get('/projects', auth.ensureLogin, panoptesProxy.getProjects)
+app.get('/subject-sets', auth.ensureLogin, panoptesProxy.getSubjectSets)
 
 const port = process.env.PORT || 3736
 server.listen(port, function(error){


### PR DESCRIPTION
Adds support for refresh tokens, meaning once you've logged in, the backend will be permanently authorised to make Panoptes requests on your behalf.

I've still got a niggling concern that the `panoptes-client` module isn't really setup for multiple users to be using it at once (it exports a singleton for the auth and api client). I'm worried that we might encounter a problem if we have multiple requests from different users come through at the same time, because our requests go like this:

1. Stuff user's access token into api client's headers
2. Make request, e.g. `apiClient.type('projects').get()`
3. Clear the access token from the api client's headers

Maybe @brian-c could advise?